### PR TITLE
Replace non-latin characters with hex codes before encoding

### DIFF
--- a/src/png.js
+++ b/src/png.js
@@ -10,7 +10,7 @@ function downloadPng(source, filename = DEFAULT_FILENAME) {
   canvas.style.display = 'none'
 
   const context = canvas.getContext('2d')
-  const imgsrc = `data:image/svg+xml;base64,${btoa(source.source)}`
+  const imgsrc = `data:image/svg+xml;base64,${btoa(source.source.replace(/[\u00A0-\u2666]/g, c => '&#' + c.charCodeAt(0) + ';'))}`
   const image = new Image()
 
   function onLoad() {

--- a/src/png.js
+++ b/src/png.js
@@ -10,7 +10,8 @@ function downloadPng(source, filename = DEFAULT_FILENAME) {
   canvas.style.display = 'none'
 
   const context = canvas.getContext('2d')
-  const imgsrc = `data:image/svg+xml;base64,${btoa(source.source.replace(/[\u00A0-\u2666]/g, c => '&#' + c.charCodeAt(0) + ';'))}`
+  const safeSource = source.source.replace(/[\u00A0-\u2666]/g, c => `&#${c.charCodeAt(0)};`)
+  const imgsrc = `data:image/svg+xml;base64,${btoa(safeSource)}`
   const image = new Image()
 
   function onLoad() {


### PR DESCRIPTION
I was running into the error "Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range." when trying to render PNGs.  Found this stack overflow:

https://stackoverflow.com/questions/23223718/failed-to-execute-btoa-on-window-the-string-to-be-encoded-contains-characte

This might not be the best way to address it, but it works for me locally.