### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
   apt:
     packages:
       - xvfb
+      - libgconf-2-4
 
 install:
   - npm install


### PR DESCRIPTION
get rid of the "libgconf-2.so.4: cannot open shared object file" error on Travis