### PR TITLE
Fixes for downloading PNG

### DIFF
--- a/src/inputProcessor.js
+++ b/src/inputProcessor.js
@@ -41,8 +41,8 @@ function getSource(svg, {css = 'inline'} = {}) {
   const result = {
     top: rect.top,
     left: rect.left,
-    width: rect.width,
-    height: rect.height,
+    width: svg.width.baseVal.value,
+    height: svg.height.baseVal.value,
     class: svg.getAttribute('class'),
     id: svg.getAttribute('id'),
     name: svg.getAttribute('name'),


### PR DESCRIPTION
Hi there,

I'd like to open my PR to further the discussion on #75. This fixes two big issues for us:

1. If the DOM containing element has a variable width and height, and it contains an `<svg>` element with a `viewBox` property, then the resulting downloaded PNG will render the SVG at its own `viewBox` dimensions, which will mismatch from the DOM dimensions. This proposal renders the resulting PNG at the source SVG's `viewBox` dimensions.

2. If the user downloads a PNG from a monitor with a high pixel density (such as a Macbook with a Retina screen) then the resulting PNG will be pixelated. This PR renders the resulting PNG at the same pixel density as the user's monitor.

There is a broken test because reading `baseVal` from an empty SVG throws an error. This might take time to fix, so I'd like to open this for further conversation so I can decide how to approach this. Thanks!