### PR TITLE
Add 3rd CSS argument to allow inline/internal/none

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is also possible to use this library to convert an SVG to a PNG before downlo
 ```javascript
 import downloadSvg from 'svg-crowbar';
 
-downloadSvg(document.querySelector('svg'), 'my_svg', 'external');
+downloadSvg(document.querySelector('svg'), 'my_svg', 'internal');
 ```    
 or
 ```javascript
@@ -25,6 +25,6 @@ downloadPng(document.querySelector('svg'));
 
 Filename is determined by element id, class or page title, when not provided explicitly.
 
-The optional third argument (which defaults to `'inline'`) can be set to `'external'` if you wish to use a block of styles from `document.styleSheets`, instead of adding inline styles from `getComputedStyle` on every element in the SVG. If you'd prefer that no CSS be added, then set the value to `false`.
+The optional third argument (which defaults to `'inline'`) can be set to `'internal'` if you wish to use a block of styles from `document.styleSheets`, instead of adding inline styles from `getComputedStyle` on every element in the SVG. If you'd prefer that no CSS be added, then set the value to `false`.
 
 An error is thrown in case no valid SVG element was provided.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ downloadPNG(svgElement, [filename], [options])
 
     Adds an internal block of styles containing only explicitly declared style rules (from `document.styleSheets`). This can drastically reduce file-sizes and build time in exported SVGs, but could be less accurate if the styles are not consistent cross-browser, as it does not include styles from the browser's user agent stylesheet.
 
-  - **`false`**
+  - **`'none'`**
 
     Doesn't add any CSS. This gives the smallest file-size, but you might need to manually add your own styles to exported SVGs to ensure an accurate output. You can do this by injecting a `<style>` block into the selected SVG before exporting.
 
@@ -70,5 +70,5 @@ downloadPNG(svgElement, [filename], [options])
   downloadSvg(svg, 'my_svg', { css: 'internal' });
 
   // Do not add CSS:
-  downloadSvg(svg, 'my_svg', { css: false });
+  downloadSvg(svg, 'my_svg', { css: 'none' });
   ```

--- a/README.md
+++ b/README.md
@@ -23,42 +23,52 @@ import { downloadPng } from 'svg-crowbar';
 downloadPng(document.querySelector('svg'), 'my_svg', { css: 'internal' });
 ```
 
-### Function arguments
-
-The `downloadSVG`/`downloadPNG` functions both have three arguments:
+The `downloadSVG`/`downloadPNG` functions each have three arguments:
 
 ```javascript
 downloadSVG([svgElement], [filename], [options])
 downloadPNG([svgElement], [filename], [options])
 ```
 
-#### svgElement (required)
+- **svgElement** *(required)*
+  
+  A DOM element selector for an SVG, e.g. `document.querySelector('svg')`. An error is thrown if no valid SVG element was provided.
 
-A DOM element selector for an SVG, e.g. `document.querySelector('svg')`. An error is thrown if no valid SVG element was provided.
+- **filename** *(optional)*
 
-#### filename (optional)
+  A string to set the filename. This is determined by element id, class or page title, when not provided explicitly.
 
-A string to set the filename. This is determined by element id, class or page title, when not provided explicitly.
+- **options** *(optional)*
 
-#### options (optional)
+  An object literal. It presently has just a single configurable property:
 
-An object literal. It presently has just a single configurable property:
+- **options.css** *(optional)*
 
-#### options.css (optional)
+  This setting determines how the SVG will be styled:
 
-This setting determines how the SVG will be styled:
+  - **`'inline'`**
 
-- `'inline'`: Default value. Adds inline styles from `getComputedStyle` on every element in the SVG.
-- `'internal'`: Add an internal block of styles containing style rules from `document.styleSheets` instead.
-- `false`: Don't add any CSS.
+    Default value. Inlines all computed styles on every element in the SVG. This setting best ensures that the exported SVG is accurate cross-browser.
 
-Example:
-```javascript
-// Add inline styles on SVG elements:
-downloadSvg(document.querySelector('svg'), 'my_svg'); 
-downloadSvg(document.querySelector('svg'), 'my_svg', { css: 'inline' });
-// Add a <style> block in the SVG:
-downloadSvg(document.querySelector('svg'), 'my_svg', { css: 'internal' });
-// Do not add CSS:
-downloadSvg(document.querySelector('svg'), 'my_svg', { css: false });
-```
+  - **`'internal'`**
+
+    Adds an internal block of styles containing only explicitly declared style rules (from `document.styleSheets`). This can drastically reduce file-sizes and build time in exported SVGs, but could be less accurate if the styles are not consistent cross-browser, as it does not include styles from the browser's user agent stylesheet.
+
+  - **`false`**
+
+    Doesn't add any CSS. This gives the smallest file-size, but you might need to manually add your own styles to exported SVGs to ensure an accurate output. You can do this by injecting a `<style>` block into the selected SVG before exporting.
+
+  Example:
+  ```javascript
+  const svg = document.querySelector('svg');
+
+  // Add inline styles on SVG elements:
+  downloadSvg(svg, 'my_svg'); 
+  downloadSvg(svg, 'my_svg', { css: 'inline' });
+
+  // Add a <style> block in the SVG:
+  downloadSvg(svg, 'my_svg', { css: 'internal' });
+
+  // Do not add CSS:
+  downloadSvg(svg, 'my_svg', { css: false });
+  ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A standalone 3.5Kb JS client library based on Chrome [bookmarklet](https://nytimes.github.io/svg-crowbar/).
 
-The library provides functionality to trigger a download of a given SVG file having alle the styles inlined,
+The library provides functionality to trigger a download of a given SVG file having all the styles inlined,
 to make it look the same when opened independently from the original HTML page.
 
 It is also possible to use this library to convert an SVG to a PNG before downloading.
@@ -14,17 +14,51 @@ It is also possible to use this library to convert an SVG to a PNG before downlo
 ```javascript
 import downloadSvg from 'svg-crowbar';
 
-downloadSvg(document.querySelector('svg'), 'my_svg', 'internal');
+downloadSvg(document.querySelector('svg'));
 ```    
 or
 ```javascript
 import { downloadPng } from 'svg-crowbar';
 
-downloadPng(document.querySelector('svg'));
+downloadPng(document.querySelector('svg'), 'my_svg', { css: 'internal' });
 ```
 
-Filename is determined by element id, class or page title, when not provided explicitly.
+### Function arguments
 
-The optional third argument (which defaults to `'inline'`) can be set to `'internal'` if you wish to use a block of styles from `document.styleSheets`, instead of adding inline styles from `getComputedStyle` on every element in the SVG. If you'd prefer that no CSS be added, then set the value to `false`.
+The `downloadSVG`/`downloadPNG` functions both have three arguments:
 
-An error is thrown in case no valid SVG element was provided.
+```javascript
+downloadSVG([svgElement], [filename], [options])
+downloadPNG([svgElement], [filename], [options])
+```
+
+#### svgElement (required)
+
+A DOM element selector for an SVG, e.g. `document.querySelector('svg')`. An error is thrown if no valid SVG element was provided.
+
+#### filename (optional)
+
+A string to set the filename. This is determined by element id, class or page title, when not provided explicitly.
+
+#### options (optional)
+
+An object literal. It presently has just a single configurable property:
+
+#### options.css (optional)
+
+This setting determines how the SVG will be styled:
+
+- `'inline'`: Default value. Adds inline styles from `getComputedStyle` on every element in the SVG.
+- `'internal'`: Add an internal block of styles containing style rules from `document.styleSheets` instead.
+- `false`: Don't add any CSS.
+
+Example:
+```javascript
+// Add inline styles on SVG elements:
+downloadSvg(document.querySelector('svg'), 'my_svg'); 
+downloadSvg(document.querySelector('svg'), 'my_svg', { css: 'inline' });
+// Add a <style> block in the SVG:
+downloadSvg(document.querySelector('svg'), 'my_svg', { css: 'internal' });
+// Do not add CSS:
+downloadSvg(document.querySelector('svg'), 'my_svg', { css: false });
+```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is also possible to use this library to convert an SVG to a PNG before downlo
 ```javascript
 import downloadSvg from 'svg-crowbar';
 
-downloadSvg(document.querySelector('svg'), 'my_svg');
+downloadSvg(document.querySelector('svg'), 'my_svg', 'external');
 ```    
 or
 ```javascript
@@ -24,5 +24,7 @@ downloadPng(document.querySelector('svg'));
 ```
 
 Filename is determined by element id, class or page title, when not provided explicitly.
+
+The optional third argument (which defaults to `'inline'`) can be set to `'external'` if you wish to use a block of styles from `document.styleSheets`, instead of adding inline styles from `getComputedStyle` on every element in the SVG. If you'd prefer that no CSS be added, then set the value to `false`.
 
 An error is thrown in case no valid SVG element was provided.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ downloadPng(document.querySelector('svg'), 'my_svg', { css: 'internal' });
 The `downloadSVG`/`downloadPNG` functions each have three arguments:
 
 ```javascript
-downloadSVG([svgElement], [filename], [options])
-downloadPNG([svgElement], [filename], [options])
+downloadSVG(svgElement, [filename], [options])
+downloadPNG(svgElement, [filename], [options])
 ```
 
 - **svgElement** *(required)*

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,9 @@ import download from './svg'
 import downloadPNG from './png'
 import {getFilename} from './util'
 
-const downloadSvg = (svgElement, filename) =>
-  download(getSource(svgElement), filename || getFilename(svgElement))
+const downloadSvg = (svgElement, filename, css) =>
+  download(getSource(svgElement, css), filename || getFilename(svgElement))
 export default downloadSvg
-const downloadPng = (svgElement, filename) =>
-  downloadPNG(getSource(svgElement), filename || getFilename(svgElement))
+const downloadPng = (svgElement, filename, css) =>
+  downloadPNG(getSource(svgElement, css), filename || getFilename(svgElement))
 export {downloadPng}

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,9 @@ import download from './svg'
 import downloadPNG from './png'
 import {getFilename} from './util'
 
-const downloadSvg = (svgElement, filename, css) =>
-  download(getSource(svgElement, css), filename || getFilename(svgElement))
+const downloadSvg = (svgElement, filename, options) =>
+  download(getSource(svgElement, options), filename || getFilename(svgElement))
 export default downloadSvg
-const downloadPng = (svgElement, filename, css) =>
-  downloadPNG(getSource(svgElement, css), filename || getFilename(svgElement))
+const downloadPng = (svgElement, filename, options) =>
+  downloadPNG(getSource(svgElement, options), filename || getFilename(svgElement))
 export {downloadPng}

--- a/src/inputProcessor.js
+++ b/src/inputProcessor.js
@@ -10,7 +10,7 @@ function getEmptySvgDeclarationComputed() {
   return emptySvgDeclarationComputed
 }
 
-function getSource(svg, css = 'inline') {
+function getSource(svg, options = {}) {
   if (!(svg instanceof SVGElement)) {
     throw new Error('SVG element is required')
   }
@@ -29,9 +29,9 @@ function getSource(svg, css = 'inline') {
     svg.setAttributeNS(prefix.xmlns, 'xmlns:xlink', prefix.xlink)
   }
 
-  if (css === 'inline') {
+  if (!options.hasOwnProperty('css') || options.css === 'inline') {
     setInlineStyles(svg, getEmptySvgDeclarationComputed())
-  } else if (css === 'internal') {
+  } else if (options.css === 'internal') {
     setInternalStyles(svg)
   }
 

--- a/src/inputProcessor.js
+++ b/src/inputProcessor.js
@@ -10,7 +10,7 @@ function getEmptySvgDeclarationComputed() {
   return emptySvgDeclarationComputed
 }
 
-function getSource(svg, {css = 'inline'}) {
+function getSource(svg, {css = 'inline'} = {}) {
   if (!(svg instanceof SVGElement)) {
     throw new Error('SVG element is required')
   }

--- a/src/inputProcessor.js
+++ b/src/inputProcessor.js
@@ -96,8 +96,12 @@ function setInlineStyles(svg, emptySvgDeclarationComputed) {
 
 function setInternalStyles(svg) {
   const style = document.createElement('style')
-  style.innerHTML = [...document.styleSheets]
-    .map(styleSheet => [...styleSheet.cssRules].map(rule => rule.cssText).join(' '))
+  style.innerHTML = Array.from(document.styleSheets)
+    .map(styleSheet =>
+      Array.from(styleSheet.cssRules)
+        .map(rule => rule.cssText)
+        .join(' '),
+    )
     .join(' ')
   svg.prepend(style)
 }

--- a/src/inputProcessor.js
+++ b/src/inputProcessor.js
@@ -10,11 +10,10 @@ function getEmptySvgDeclarationComputed() {
   return emptySvgDeclarationComputed
 }
 
-function getSource(svg) {
+function getSource(svg, css = 'inline') {
   if (!(svg instanceof SVGElement)) {
     throw new Error('SVG element is required')
   }
-  const emptySvgDeclarationComputed = getEmptySvgDeclarationComputed()
 
   svg.setAttribute('version', '1.1')
   // removing attributes so they aren't doubled up
@@ -30,7 +29,11 @@ function getSource(svg) {
     svg.setAttributeNS(prefix.xmlns, 'xmlns:xlink', prefix.xlink)
   }
 
-  setInlineStyles(svg, emptySvgDeclarationComputed)
+  if (css === 'inline') {
+    setInlineStyles(svg, getEmptySvgDeclarationComputed())
+  } else if (css === 'external') {
+    setExternalStyles(svg)
+  }
 
   const source = new XMLSerializer().serializeToString(svg)
   const rect = svg.getBoundingClientRect()
@@ -89,6 +92,14 @@ function setInlineStyles(svg, emptySvgDeclarationComputed) {
   while (i--) {
     explicitlySetStyle(allElements[i])
   }
+}
+
+function setExternalStyles(svg) {
+  const style = document.createElement('style')
+  style.innerHTML = [...document.styleSheets]
+    .map(styleSheet => [...styleSheet.cssRules].map(rule => rule.cssText).join(' '))
+    .join(' ')
+  svg.prepend(style)
 }
 
 export default getSource

--- a/src/inputProcessor.js
+++ b/src/inputProcessor.js
@@ -31,8 +31,8 @@ function getSource(svg, css = 'inline') {
 
   if (css === 'inline') {
     setInlineStyles(svg, getEmptySvgDeclarationComputed())
-  } else if (css === 'external') {
-    setExternalStyles(svg)
+  } else if (css === 'internal') {
+    setInternalStyles(svg)
   }
 
   const source = new XMLSerializer().serializeToString(svg)
@@ -94,7 +94,7 @@ function setInlineStyles(svg, emptySvgDeclarationComputed) {
   }
 }
 
-function setExternalStyles(svg) {
+function setInternalStyles(svg) {
   const style = document.createElement('style')
   style.innerHTML = [...document.styleSheets]
     .map(styleSheet => [...styleSheet.cssRules].map(rule => rule.cssText).join(' '))

--- a/src/inputProcessor.js
+++ b/src/inputProcessor.js
@@ -10,7 +10,7 @@ function getEmptySvgDeclarationComputed() {
   return emptySvgDeclarationComputed
 }
 
-function getSource(svg, options = {}) {
+function getSource(svg, {css = 'inline'}) {
   if (!(svg instanceof SVGElement)) {
     throw new Error('SVG element is required')
   }
@@ -29,9 +29,9 @@ function getSource(svg, options = {}) {
     svg.setAttributeNS(prefix.xmlns, 'xmlns:xlink', prefix.xlink)
   }
 
-  if (!options.hasOwnProperty('css') || options.css === 'inline') {
+  if (css === 'inline') {
     setInlineStyles(svg, getEmptySvgDeclarationComputed())
-  } else if (options.css === 'internal') {
+  } else if (css === 'internal') {
     setInternalStyles(svg)
   }
 


### PR DESCRIPTION
## Description

When exporting large SVGs with many elements, the volume of inline styles can make the resulting file extremely large. For instance, the ones I'm exporting regularly exceed 3MB.

This PR adds the ability to turn this feature off (to allow users to add CSS manually instead), or to add the document's stylesheets (from `document.styleSheets`) in a single `<style>` block instead. While these stylesheets will likely still contain unnecessary styles, in cases with many SVG elements, they'll still be a lot smaller than the inlined styles, and easier to remove or modify if necessary.

New usage:
```javascript
// Add inline styles on SVG elements:
downloadSvg(document.querySelector('svg'), 'my_svg'); 
downloadSvg(document.querySelector('svg'), 'my_svg', { css: 'inline' });
// Add a <style> block in the SVG:
downloadSvg(document.querySelector('svg'), 'my_svg', { css: 'internal' });
// Do not add CSS:
downloadSvg(document.querySelector('svg'), 'my_svg', { css: false });
```

In practice, this allowed me to reduce the size of my exported SVGs from 3MB to 156KB, without changing how they look.

## Development notes

- This PR uses ES6 spread syntax in order to convert the StyleSheetList into an array. It also uses ES6 default parameters. These won't work in older browsers. If need be, I can convert it into ES5 syntax.
- ~3 arguments is kind of a lot. I haven't done it yet, but my tentative suggestion is to convert the new one into an 'options' object literal, in order to allow future changes in a backwards-compatible way.~
  
  ~Ideally I'd have done this for the second argument, but now that it's in there, probably better to just make the third argument the object, in order not to introduce a breaking change.~
  
  Edit: I have now updated this as per request