### PR TITLE
Add test & build task to prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint ./src",
     "lint-fix": "eslint --fix ./src",
     "build": "webpack src/index.js --mode=production",
-    "build-dev": "webpack src/index.js --mode=development"
+    "build-dev": "webpack src/index.js --mode=development",
+    "prepublishOnly": "npm test && npm run build"
   },
   "repository": "git+https://github.com/cy6erskunk/svg-crowbar.git",
   "keywords": [


### PR DESCRIPTION
This will prevent publishing builds to npm which fail tests, and ensure that published versions contain the latest code.

Resolves #113