### PR TITLE
Remove references to global window object to fix SSR builds

### DIFF
--- a/src/inputProcessor.js
+++ b/src/inputProcessor.js
@@ -1,7 +1,7 @@
 import {doctype, prefix} from './const'
 
 function getEmptySvgDeclarationComputed() {
-  let emptySvg = window.document.createElementNS(prefix.svg, 'svg')
+  let emptySvg = document.createElementNS(prefix.svg, 'svg')
   document.body.appendChild(emptySvg)
   emptySvg.style.all = 'initial'
   const emptySvgDeclarationComputed = getComputedStyle(emptySvg)

--- a/src/util.js
+++ b/src/util.js
@@ -8,7 +8,7 @@ export function getFilename(source) {
   return (
     source.getAttribute('id') ||
     source.getAttribute('class') ||
-    window.document.title.replace(/[^a-z0-9]/gi, '-').toLowerCase() ||
+    document.title.replace(/[^a-z0-9]/gi, '-').toLowerCase() ||
     DEFAULT_FILENAME
   )
 }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -3,7 +3,7 @@ import {getFilename} from '../src/util'
 
 const createSVG = () => document.createElementNS(prefix.svg, 'svg')
 describe('getFilename', () => {
-  beforeEach(() => (window.document.title = ''))
+  beforeEach(() => (document.title = ''))
   test('throws when receves not  an SVG', () => {
     expect(getFilename).toThrow()
   })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   output: {
     libraryTarget: 'umd',
+    globalObject: 'this',
   },
 }


### PR DESCRIPTION
When server-side rendering JavaScript (e.g. in Gatsby.js builds), any reference to the `window` object that isn't guarded (e.g. with a check like `typeof window !== 'undefined'`) will throw an undefined reference error. This makes this library difficult to use in sites like this, as it will throw an error.

This PR fixes this issue by changing the references to `window.document` to just `document` (which should behave the same way, but without the same errors being thrown. I've also changed the global object in the UMD declaration (created by webpack during the build) from the default `window` to `this` (to fix a bug in Webpack 4, [as recommended in this blog post](https://medium.com/@JakeXiao/window-is-undefined-in-umd-library-output-for-webpack4-858af1b881df))

Thanks @cy6erskunk for your work in maintaining this excellent plugin, and for your patience with my various PRs! 😄