### PR TITLE
feat(png): saved image uses device pixel ratio

### DIFF
--- a/src/png.js
+++ b/src/png.js
@@ -3,10 +3,11 @@ import {DEFAULT_FILENAME} from './const'
 
 function downloadPng(source, filename = DEFAULT_FILENAME) {
   const canvas = document.createElement('canvas')
+  const dpr = window.devicePixelRatio || 1
   document.body.appendChild(canvas)
   canvas.setAttribute('id', 'svg-image')
-  canvas.setAttribute('width', source.width)
-  canvas.setAttribute('height', source.height)
+  canvas.setAttribute('width', source.width * dpr)
+  canvas.setAttribute('height', source.height * dpr)
   canvas.style.display = 'none'
 
   const context = canvas.getContext('2d')
@@ -15,6 +16,7 @@ function downloadPng(source, filename = DEFAULT_FILENAME) {
   const image = new Image()
 
   function onLoad() {
+    context.scale(dpr, dpr)
     context.drawImage(image, 0, 0)
     const canvasdata = canvas.toDataURL('image/png')
 


### PR DESCRIPTION
If the user downloads a PNG from a monitor with a high pixel density (such as a Macbook with a Retina screen) then the resulting PNG will be pixelated. This PR renders the resulting PNG at the same pixel density as the user's monitor.

(Extracted into a separate PR from #84.)